### PR TITLE
Allowed underscore in variables names and joined two char methods

### DIFF
--- a/src/parse/file.rs
+++ b/src/parse/file.rs
@@ -135,7 +135,7 @@ enum DataLine<'a> {
 }
 
 fn is_variable_name_char(ch: char) -> bool {
-    ch.is_ascii_alphabetic() || ch.is_ascii_digit()
+    ch.is_ascii_alphanumeric() || ch == '_'
 }
 
 fn parse_line(line: &str) -> Option<DataLine> {


### PR DESCRIPTION
Changed `is_variable_name_char` function to allow any alphanumeric characters and underscore. Also, replaced `is_ascii_alphabetic` and `is_ascii_digit` methods with single `is_ascii_alphanumeric`method. This change makes possible to use snake case for variables names.